### PR TITLE
feat(LimitRequestFieldSize): Set request header field size to 16kb.

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -122,6 +122,23 @@ ServerAdmin root@localhost
 DocumentRoot "/var/www/html"
 
 #
+# LimitRequestFieldSize: This directive specifies the number of bytes that 
+# will be allowed in an HTTP request header. The LimitRequestFieldSize 
+# directive allows the server administrator to set the limit on the allowed 
+# size of an HTTP request header field. A server needs this value to be large 
+# enough to hold any one header field from a normal client request. The size 
+# of a normal request header field will vary greatly among different client 
+# implementations, often depending upon the extent to which a user has 
+# configured their browser to support detailed content negotiation. SPNEGO
+# authentication headers can be up to 12392 bytes.
+#
+# This directive gives the server administrator greater control over abnormal 
+# client request behavior, which may be useful for avoiding some forms of 
+# denial-of-service attacks.
+#
+LimitRequestFieldSize 16384 
+
+#
 # Relax access to content within /var/www.
 #
 <Directory "/var/www">


### PR DESCRIPTION
Set `LimitRequestFieldSize` to `16384` in httpd.conf